### PR TITLE
Add resolve_filepath for url scheme such that package://, model://

### DIFF
--- a/urdfpy/utils.py
+++ b/urdfpy/utils.py
@@ -1,6 +1,12 @@
 """Utilities for URDF parsing.
 """
 import os
+try:
+    # for python3
+    from urllib.parse import urlparse
+except ImportError:
+    # for python2
+    from urlparse import urlparse
 
 from lxml import etree as ET
 import numpy as np
@@ -180,6 +186,19 @@ def unparse_origin(matrix):
     return node
 
 
+def resolve_filepath(base_path, file_path):
+    parsed_url = urlparse(file_path)
+    dirname = base_path
+    file_path = parsed_url.netloc + parsed_url.path
+    while not dirname == '/':
+        resolved_filepath = os.path.join(dirname, file_path)
+        print(resolved_filepath)
+        if os.path.exists(resolved_filepath):
+            return resolved_filepath
+        dirname = os.path.dirname(dirname)
+    return False
+
+
 def get_filename(base_path, file_path, makedirs=False):
     """Formats a file path correctly for URDF loading.
 
@@ -199,6 +218,7 @@ def get_filename(base_path, file_path, makedirs=False):
         The resolved filepath -- just the normal ``file_path`` if it was an
         absolute path, otherwise that path joined to ``base_path``.
     """
+    file_path = resolve_filepath(base_path, file_path)
     fn = file_path
     if not os.path.isabs(file_path):
         fn = os.path.join(base_path, file_path)


### PR DESCRIPTION
This PR supports URL scheme such that `package://`, `model://. 
With this PR, we can load urdf contains following XML tag.

```
<mesh filename="package://fetch_description/meshes/base_link_collision.STL" />
```