### PR TITLE
Unpinned networkx and pycollada to support new Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ from setuptools import setup
 
 requirements = [
     'lxml',             # For XML DOM Tree
-    'networkx==2.2',    # For joint graph
+    'networkx',    # For joint graph
     'numpy',            # Numpy
     'pillow',           # For texture image loading
-    'pycollada==0.6',   # COLLADA (.dae) mesh loading via trimesh
+    'pycollada',   # COLLADA (.dae) mesh loading via trimesh
     'pyrender>=0.1.20', # For visualization
     'scipy',            # For trimesh, annoyingly
     'six',              # Python 2/3 compatability
@@ -45,7 +45,6 @@ setup(
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Natural Language :: English',


### PR DESCRIPTION
By pinning networkx, newer versions of Python will not work with this library. In conda, it's already been unpinned and tested. Unpinning pycollada as well because they fixed a few bugs upstream and if we're dropping Python 2 support anyway, might as well upgrade this too.