### PR TITLE
Fix deprecation warning

### DIFF
--- a/urdfpy/urdf.py
+++ b/urdfpy/urdf.py
@@ -895,7 +895,7 @@ class Material(URDFType):
     @color.setter
     def color(self, value):
         if value is not None:
-            value = np.asanyarray(value).astype(np.float)
+            value = np.asanyarray(value).astype(np.float64)
             value = np.clip(value, 0.0, 1.0)
             if value.shape != (4,):
                 raise ValueError('Color must be a (4,) float')
@@ -2344,7 +2344,7 @@ class Joint(URDFType):
             raise ValueError('Invalid configuration')
 
     def get_child_poses(self, cfg, n_cfgs):
-        """Computes the child pose relative to a parent pose for a given set of 
+        """Computes the child pose relative to a parent pose for a given set of
         configuration values.
 
         Parameters


### PR DESCRIPTION
```
.../urdfpy/urdf.py:898: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  value = np.asanyarray(value).astype(np.float)
```
I was getting this deprecation warning quite often, so I decided to fix it.