### PR TITLE
Unpin networkx to fix python3.10 issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 requirements = [
     'lxml',             # For XML DOM Tree
-    'networkx==2.2',    # For joint graph
+    'networkx',         # For joint graph
     'numpy',            # Numpy
     'pillow',           # For texture image loading
     'pycollada==0.6',   # COLLADA (.dae) mesh loading via trimesh


### PR DESCRIPTION
Python3.10 is the default python on Ubuntu Jammy 22.04. urdfpy crashes on import due to error: `ImportError: cannot import name 'Mapping' from 'collections'` in networkx package.

After upgrading python environment using `pip install --upgrade networkx`, which upgrades to version `2.8.4`, things seem to work. The unit tests pass and I can visualize the URDF.

I did not see any indication of why this requirement was pinned in the first place.