### PR TITLE
Fix numpy type bug

### DIFF
--- a/urdfpy/urdf.py
+++ b/urdfpy/urdf.py
@@ -3227,7 +3227,7 @@ class URDF(URDFType):
                     if visual.geometry.mesh is not None:
                         if visual.geometry.mesh.scale is not None:
                             S = np.eye(4, dtype=np.float64)
-                            S[:3, :3] = np.diag(visual.geometry.mesh.scale)
+                            S[:3,:3] = np.diag(visual.geometry.mesh.scale)
                             pose = pose.dot(S)
                     fk[mesh] = pose, material
         return fk

--- a/urdfpy/urdf.py
+++ b/urdfpy/urdf.py
@@ -36,10 +36,9 @@ class URDFType(object):
     - ``_TAG`` - This is a string that represents the XML tag for the node
       containing this type of object.
     """
-
-    _ATTRIBS = {}  # Map from attrib name to (type, required)
+    _ATTRIBS = {}   # Map from attrib name to (type, required)
     _ELEMENTS = {}  # Map from element name to (type, required, multiple)
-    _TAG = ''  # XML tag for this element
+    _TAG = ''       # XML tag for this element
 
     def __init__(self):
         pass


### PR DESCRIPTION
Fix for numpy 1.20

I was getting this exception:
```
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
```

I've also added materials to the animation so the models aren't just grey.
